### PR TITLE
Disable Lambda read timeout in deployment action

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -77,7 +77,7 @@ runs:
         echo "Triggering lambda function ..."
         VERSION="${{ env.NEW_VERSION }}"
         PAYLOAD=$(jq -n --arg version "$VERSION" '{DEPLOYED_VERSION:$version}' | base64)
-        RESPONSE=$(aws lambda invoke --function-name AutoRunStartupScript --payload "$PAYLOAD" response.json --log-type Tail --query 'StatusCode' --output text)
+        RESPONSE=$(aws lambda invoke --function-name AutoRunStartupScript --payload "$PAYLOAD" response.json --log-type Tail --query 'StatusCode' --output text --cli-read-timeout 0)
         echo "Lambda function response: $RESPONSE"
         cat response.json
 


### PR DESCRIPTION
This might stop the lambda step "failing" if the deployment takes too long