### PR TITLE
Enhance AWS Parameter Store update logic to skip unnecessary updates

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -30,6 +30,8 @@ runs:
     - name: Update AWS Parameter Store
       shell: bash
       id: update
+      output:
+        updated: ${{ steps.update.outputs.UPDATED }}
       run: |
         echo "Fetching version from config/${{ inputs.config-file }}..."
 
@@ -54,19 +56,33 @@ runs:
 
         echo "New parameter value: $NEW_VALUE"
 
-        echo "Updating ${{ inputs.parameter-path }}..."
-        aws ssm put-parameter --name "${{ inputs.parameter-path }}" --value "$NEW_VALUE" --type String --overwrite
+        SHOULD_UPDATE=true
+
+        if [[ "$NEW_VALUE" == "$OLD_VALUE" ]]; then
+          echo "No changes detected in the parameter value."
+          echo "Skipping update."
+          SHOULD_UPDATE=false
+        fi
+
+        if $SHOULD_UPDATE
+        then
+          echo "Updating ${{ inputs.parameter-path }}..."
+          aws ssm put-parameter --name "${{ inputs.parameter-path }}" --value "$NEW_VALUE" --type String --overwrite
+        fi
 
         echo "NEW_VERSION=$NEW_VERSION" >> "$GITHUB_ENV"
+        echo "UPDATED=$SHOULD_UPDATE" >> "$GITHUB_ENV"
 
     - name: Verify the update
       shell: bash
+      if: steps.update.outputs.updated == 'true'
       run: |
         echo "Verifying the updated value..."
         aws ssm get-parameter --name "${{ inputs.parameter-path }}" --query "Parameter.Value" --output text
 
     - name: Trigger Lambda function
       shell: bash
+      if: steps.update.outputs.updated == 'true'
       run: |
         echo "Triggering lambda function ..."
         SERVICE="${{ inputs.service-name }}"
@@ -82,6 +98,7 @@ runs:
 
     - name: Wait for the deployed version to update
       shell: bash
+      if: steps.update.outputs.updated == 'true'
       run: |
         echo "Checking for the deployed version..."
         MAX_RETRIES=20

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -30,8 +30,6 @@ runs:
     - name: Update AWS Parameter Store
       shell: bash
       id: update
-      output:
-        updated: ${{ steps.update.outputs.UPDATED }}
       run: |
         echo "Fetching version from config/${{ inputs.config-file }}..."
 
@@ -75,14 +73,14 @@ runs:
 
     - name: Verify the update
       shell: bash
-      if: steps.update.outputs.updated == 'true'
+      if: steps.update.outputs.UPDATED == 'true'
       run: |
         echo "Verifying the updated value..."
         aws ssm get-parameter --name "${{ inputs.parameter-path }}" --query "Parameter.Value" --output text
 
     - name: Trigger Lambda function
       shell: bash
-      if: steps.update.outputs.updated == 'true'
+      if: steps.update.outputs.UPDATED == 'true'
       run: |
         echo "Triggering lambda function ..."
         SERVICE="${{ inputs.service-name }}"
@@ -98,7 +96,7 @@ runs:
 
     - name: Wait for the deployed version to update
       shell: bash
-      if: steps.update.outputs.updated == 'true'
+      if: steps.update.outputs.UPDATED == 'true'
       run: |
         echo "Checking for the deployed version..."
         MAX_RETRIES=20

--- a/.github/workflows/deploy-feature.yml
+++ b/.github/workflows/deploy-feature.yml
@@ -12,9 +12,9 @@ on:
           - develop.json
           - staging.json
           - production.json
-  push:
-    branches:
-      - "feature/**"
+  # push:
+  #   branches:
+  #     - "feature/**"
 
 concurrency:
   group: deploy-feature-${{ github.ref }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Compare develop to production
         id: build-comparison
         run: |
-          SOURCE=develop
+          [[ if ${{ inputs.copy-develop }} == 'true' ]] && SOURCE=develop || SOURCE=staging
           TARGET=production
           touch version-summary.md
 
@@ -42,7 +42,7 @@ jobs:
 
           SUMMARY=$(<version-summary.md)
           echo "## Changes" >> $GITHUB_STEP_SUMMARY
-          echo "\`develop\` -> \`production\`" >> $GITHUB_STEP_SUMMARY
+          echo "\`$SOURCE\` -> \`$TARGET\`" >> $GITHUB_STEP_SUMMARY
           echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY
 
           SUMMARY_CLEAN=$(sed -e "s/\`/\\\\\`/g" version-summary.md)


### PR DESCRIPTION
Could you please just check my logic here @Vaishnavir9901?

What I am trying to achieve is that if the application version hasn't changed then we have no need to run the lambda or wait for the deployment update.

_Hopefully_ this means faster deployments.