### PR TITLE
Add support for .well-known location in web-frontend configuration

### DIFF
--- a/components/terraform/nginx-conf/scripts/web-frontend.conf
+++ b/components/terraform/nginx-conf/scripts/web-frontend.conf
@@ -62,6 +62,13 @@
             proxy_pass $ups_web_frontend/$is_args$args;
         }
 
+        location ~* ^/.well-known/(.*)$ {
+            proxy_intercept_errors off;
+            proxy_set_header Host $host;
+            proxy_set_header x-target "web-frontend";
+            proxy_pass $ups_web_frontend/.well-known/$1$is_args$args;
+        }
+
         location = /maintenance {
             rewrite ^([^.]*[^/])$ $1/ permanent;
         }


### PR DESCRIPTION
I don't know if this will overwrite the routes to the local files in the nginx image or not... I'm hoping so!

I don't know where these files are currently copied into: https://github.com/nationalarchives/ds-frontend-content-disclosure-policy